### PR TITLE
Add health endpoint to service for ELB health checks

### DIFF
--- a/helm/aqua-app-server/templates/gate-service.yaml
+++ b/helm/aqua-app-server/templates/gate-service.yaml
@@ -17,6 +17,10 @@ spec:
   selector:
     app: {{ .Release.Name }}-gateway
   ports:
+  - port: 8082
+    targetPort: 8082
+    protocol: TCP
+    name: aqua-health
   - port: {{ .Values.gate.service.externalPort }}
     targetPort: 3622
     protocol: TCP


### PR DESCRIPTION
This PR fixes the warnings in the Gateway logs due to ELB health check on the SSH service port. 
https://support.aquasec.com/support/solutions/articles/16000099989-tls-handshake-with-client-failed-client-may-be-attempting-to-initiate-a-non-ssh-connection-eof