### PR TITLE
make update strategy depend on PV access mode

### DIFF
--- a/helm/aqua-app-server/templates/web-deployment.yaml
+++ b/helm/aqua-app-server/templates/web-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.web.replicaCount }}
+  {{- if eq .Values.web.persistence.accessMode "ReadWriteOnce" }}
+  strategy:
+    type: Recreate
+  {{- end}}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-console


### PR DESCRIPTION
Default update strategy "RollingUpdate" does not work for deployments that mount in a PVC with accessMode "ReadWriteOnce". The new pod is unable to mount the PVC while the old one is still running.