### PR TITLE
Migrate to gs catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ workflows:
     jobs:
       - architect/push-to-app-catalog:
           name: "package and push Aqua Server chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          app_catalog: "giantswarm-catalog"
+          app_catalog_test: "giantswarm-test-catalog"
           chart: "aqua-app-server"
           # Trigger job on git tag.
           filters:
@@ -16,8 +16,8 @@ workflows:
               only: /^v.*/
       - architect/push-to-app-catalog:
           name: "package and push Aqua Enforcer chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          app_catalog: "giantswarm-catalog"
+          app_catalog_test: "giantswarm-test-catalog"
           chart: "aqua-app-enforcer"
           # Trigger job on git tag.
           filters:
@@ -27,8 +27,8 @@ workflows:
             - "package and push Aqua Server chart"
       - architect/push-to-app-catalog:
           name: "package and push Aqua Scanner chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          app_catalog: "giantswarm-catalog"
+          app_catalog_test: "giantswarm-test-catalog"
           chart: "aqua-app-scanner"
           # Trigger job on git tag.
           filters:


### PR DESCRIPTION
towards giantswarm/roadmap/issues/47

there was some confusion around which catalog Aqua was meant to be moved to - it should have been the gs catalog all along.
