### PR TITLE
ensure boolean env vars are quoted

### DIFF
--- a/helm/aqua-app-server/templates/gate-deployment.yaml
+++ b/helm/aqua-app-server/templates/gate-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: AQUA_CONSOLE_SECURE_ADDRESS
           value: "{{ .Release.Name }}-console-svc:443"
         - name: AQUA_WORKLOADS_INTEGRITY_CHECK
-          value: {{ .Values.gate.integrityCheck | default "true" }}
+          value: {{ .Values.gate.integrityCheck | default "true" | quote }}
         - name: SCALOCK_GATEWAY_PUBLIC_IP
           value: {{ .Values.gate.publicIP | default "aqua-gateway-svc" }}
         - name: HEALTH_MONITOR

--- a/helm/aqua-app-server/templates/web-deployment.yaml
+++ b/helm/aqua-app-server/templates/web-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         imagePullPolicy: "{{ .Values.web.image.pullPolicy }}"
         env:
         - name: AQUA_ASSET_INTEGRITY_CHECK
-          value: {{ .Values.web.integrityCheck | default "true" }}
+          value: {{ .Values.web.integrityCheck | default "true" | quote }}
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
           {{- if .Values.db.passwordSecret }}


### PR DESCRIPTION
this fixes an issue introduced in v4.6.1 where the helm release fails due to unquoted boolean env vars.
