### PR TITLE
Add Aqua values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Added values.schema.json to validate default values
+
 ## [4.6.3] - 2020-09-02
 
 ### Changed

--- a/helm/aqua-app-enforcer/Chart.yaml
+++ b/helm/aqua-app-enforcer/Chart.yaml
@@ -5,6 +5,8 @@ home: https://www.aquasec.com/
 icon: https://www.aquasec.com/wp-content/uploads/2016/05/aqua_logo_fullcolor.png
 sources:
 - https://github.com/aquasecurity/aqua-helm
+annotations:
+    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/aqua-app/v[[ .Version ]]/helm/aqua-app-enforcer/values.schema.json
 name: aqua-app-enforcer
 appVersion: "4.6.0"
 version: [[ .Version ]]

--- a/helm/aqua-app-enforcer/values.schema.json
+++ b/helm/aqua-app-enforcer/values.schema.json
@@ -1,0 +1,119 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "enforcerLogicalName": {
+            "type": "null"
+        },
+        "enforcerToken": {
+            "type": "string"
+        },
+        "enforcerTokenSecretKey": {
+            "type": "null"
+        },
+        "enforcerTokenSecretName": {
+            "type": "null"
+        },
+        "gate": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "grpcKeepAliveInterval": {
+            "type": "integer"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imageCredentials": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "repositoryUriPrefix": {
+                    "type": "string"
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object"
+        },
+        "memoryPressure": {
+            "type": "null"
+        },
+        "networkFailMode": {
+            "type": "null"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "privileged": {
+            "type": "boolean"
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "roleRef": {
+                    "type": "null"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "runcInterception": {
+            "type": "boolean"
+        },
+        "scanningMemoryLimit": {
+            "type": "integer"
+        },
+        "sendingHostImagesDisables": {
+            "type": "boolean"
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/helm/aqua-app-scanner/Chart.yaml
+++ b/helm/aqua-app-scanner/Chart.yaml
@@ -5,6 +5,8 @@ home: https://www.aquasec.com/
 icon: https://www.aquasec.com/wp-content/uploads/2016/05/aqua_logo_fullcolor.png
 sources:
 - https://github.com/aquasecurity/aqua-helm
+annotations:
+    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/aqua-app/v[[ .Version ]]/helm/aqua-app-scanner/values.schema.json
 name: aqua-app-scanner
 appVersion: "4.6.0"
 version: [[ .Version ]]

--- a/helm/aqua-app-scanner/values.schema.json
+++ b/helm/aqua-app-scanner/values.schema.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imageCredentials": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "repositoryUriPrefix": {
+                    "type": "string"
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "password": {
+            "type": "null"
+        },
+        "passwordKey": {
+            "type": ["null", "string"]
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "roleRef": {
+                    "type": "null"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "secretName": {
+            "type": ["null", "string"]
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer"
+                },
+                "serviceName": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "string"
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "user": {
+            "type": "null"
+        },
+        "userKey": {
+            "type": ["null", "string"]
+        }
+    }
+}

--- a/helm/aqua-app-scanner/values.schema.json
+++ b/helm/aqua-app-scanner/values.schema.json
@@ -37,7 +37,7 @@
             "type": "object"
         },
         "password": {
-            "type": "null"
+            "type": ["null", "string"]
         },
         "passwordKey": {
             "type": ["null", "string"]
@@ -83,7 +83,7 @@
             "type": "array"
         },
         "user": {
-            "type": "null"
+            "type": ["null", "string"]
         },
         "userKey": {
             "type": ["null", "string"]

--- a/helm/aqua-app-server/Chart.yaml
+++ b/helm/aqua-app-server/Chart.yaml
@@ -5,6 +5,8 @@ home: https://www.aquasec.com/
 icon: https://www.aquasec.com/wp-content/uploads/2016/05/aqua_logo_fullcolor.png
 sources:
 - https://github.com/aquasecurity/aqua-helm
+annotations:
+    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/aqua-app/v[[ .Version ]]/helm/aqua-app-server/values.schema.json
 name: aqua-app-server
 appVersion: "4.6.0"
 version: [[ .Version ]]

--- a/helm/aqua-app-server/values.schema.json
+++ b/helm/aqua-app-server/values.schema.json
@@ -1,0 +1,523 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "admin": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "null"
+                },
+                "passwordkey": {
+                    "type": ["null", "string"]
+                },
+                "secretname": {
+                    "type": ["null", "string"]
+                },
+                "token": {
+                    "type": "null"
+                },
+                "tokenkey": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "clustermode": {
+            "type": "boolean"
+        },
+        "db": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "auditssl": {
+                    "type": "boolean"
+                },
+                "dbAuditPasswordKey": {
+                    "type": ["null", "string"]
+                },
+                "dbAuditPasswordName": {
+                    "type": ["null", "string"]
+                },
+                "dbPasswordKey": {
+                    "type": ["null", "string"]
+                },
+                "dbPasswordName": {
+                    "type": ["null", "string"]
+                },
+                "external": {
+                    "type": "object",
+                    "properties": {
+                        "auditHost": {
+                            "type": ["null", "string"]
+                        },
+                        "auditName": {
+                            "type": ["null", "string"]
+                        },
+                        "auditPassword": {
+                            "type": "null"
+                        },
+                        "auditPort": {
+                            "type": ["null", "integer"]
+                        },
+                        "auditUser": {
+                            "type": ["null", "string"]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": ["null", "string"]
+                        },
+                        "name": {
+                            "type": ["null", "string"]
+                        },
+                        "password": {
+                            "type": "null"
+                        },
+                        "port": {
+                            "type": ["null", "integer"]
+                        },
+                        "user": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "passwordSecret": {
+                    "type": ["null", "boolean"]
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "accessMode": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ssl": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "dockerless": {
+            "type": "boolean"
+        },
+        "gate": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "disconnectionGracePeriod": {
+                    "type": "null"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "kubernetes.io/ingress.class": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "null"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "integrityCheck": {
+                    "type": ["null", "boolean"]
+                },
+                "livenessProbe": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "pingCheck": {
+                    "type": "null"
+                },
+                "publicIP": {
+                    "type": "string"
+                },
+                "readinessProbe": {
+                    "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "externalPort": {
+                            "type": "integer"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "imageCredentials": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "repositoryUriPrefix": {
+                    "type": "string"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "privileged": {
+                    "type": "boolean"
+                },
+                "roleRef": {
+                    "type": "null"
+                }
+            }
+        },
+        "scanner": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "password": {
+                    "type": "null"
+                },
+                "readinessProbe": {
+                    "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "user": {
+                    "type": "null"
+                }
+            }
+        },
+        "web": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "encryptionKey": {
+                    "type": "null"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "kubernetes.io/ingress.class": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": ["null", "array"],
+                            "items": {
+                              "type": "string"
+                            }
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "integrityCheck": {
+                    "type": ["null", "boolean"]
+                },
+                "livenessProbe": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "accessMode": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "storageClass": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "proxy": {
+                    "type": "object",
+                    "properties": {
+                        "httpProxy": {
+                            "type": "null"
+                        },
+                        "httpsProxy": {
+                            "type": "null"
+                        },
+                        "noProxy": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "externalPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/136 with @oponder 

This PR adds `values.schema.json` generated from the current values.yaml using https://github.com/karuppiah7890/helm-schema-gen

It is a good starting point and can be further refined by those that know more about the specifics of the values. (For example if we know that `provider` must be aws|azure|kvm, we can actually enforce that as well using the 'enum' property: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values)

Here's also some more general info: https://www.arthurkoziel.com/validate-helm-chart-values-with-json-schemas/

I tested the following in asgard:
- aqua-app-enforcer in 05ri3
- aqua-app-scanner in 3suha
- aqua-app-server in 3suha

Initially, I got errors where the default value is "null" but the actual value customer is using in a working app can actually be a string, boolean, and so on.

**For example, in aqua-app-scanner:**
```
(⎈ |giantswarm-asgard:default)➜  kubectl-gs git:(app-validate) ./kubectl-gs validate apps -n 3suha aqua-app-scanner -f=/Users/chiaracokieng/Documents/GitHub/aqua-app/helm/aqua-app-scanner/values.schema.json -o report

Validated 1 app across 1 namespace

3suha [1 app, 3 errors]
  aqua-app-scanner:
    secretName - Invalid type. Expected: null, given: string - aqua-app-scanner-secret
    userKey - Invalid type. Expected: null, given: string - user
    passwordKey - Invalid type. Expected: null, given: string - password
```

**In those cases, I modified the values.schema.json file to accommodate either null or string, etc.**

Got more of these in aqua-app-server.

---

I used the currently in progress `kubectl-gs validate apps` command to help with the verifying current values : https://github.com/giantswarm/kubectl-gs/pull/196

Here's also a slack thread with a video about how that command works: https://gigantic.slack.com/archives/CRZN9GLJW/p1603092812002400