### PR TITLE
fixing db secret bug| adding security context

### DIFF
--- a/helm/aqua-app-server/templates/db-deployment.yaml
+++ b/helm/aqua-app-server/templates/db-deployment.yaml
@@ -23,20 +23,49 @@ spec:
         app: {{ .Release.Name }}-database
       name: {{ .Release.Name }}-database
     spec:
+      {{- with .Values.db.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Name }}-sa
-      containers:
-      - name: db
-        securityContext:
-          {{- toYaml .Values.db.securityContext | nindent 12 }}
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
-        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+      initContainers:
+      - name: {{ .Release.Name }}-db-init
         env:
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: db-password
+        {{- end }}
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/db-files"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-database
+      containers:
+      - name: db
+        {{- with .Values.db.container_securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+        env:
+        {{- if .Values.db.passwordFromSecret.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
         {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:
@@ -106,20 +135,49 @@ spec:
         app: {{ .Release.Name }}-audit-database
       name: {{ .Release.Name }}-audit-database
     spec:
+      {{- with .Values.db.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Name }}-sa
-      containers:
-      - name: auditdb
-        securityContext:
-          {{- toYaml .Values.db.securityContext | nindent 12 }}
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
-        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+      initContainers:
+      - name: {{ .Release.Name }}-auditdb-init
         env:
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
+        {{- end }}
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/db-files"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-audit-database
+      containers:
+      - name: auditdb
+        {{- with .Values.db.container_securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+        env:
+        {{- if .Values.db.passwordFromSecret.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
         {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/helm/aqua-app-server/templates/db-password-secret.yaml
+++ b/helm/aqua-app-server/templates/db-password-secret.yaml
@@ -1,5 +1,5 @@
 
-{{- if not .Values.db.passwordSecret }}
+{{- if not .Values.db.passwordFromSecret.enabled }}
 {{- if .Values.db.external.enabled }}
 ---
 apiVersion: v1

--- a/helm/aqua-app-server/templates/gate-deployment.yaml
+++ b/helm/aqua-app-server/templates/gate-deployment.yaml
@@ -22,11 +22,17 @@ spec:
         app: {{ .Release.Name }}-gateway
       name: {{ .Release.Name }}-gateway
     spec:
+      {{- with .Values.gate.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: gate
+        {{- with .Values.gate.container_securityContext }}
         securityContext:
-          {{- toYaml .Values.gate.securityContext | nindent 12 }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.gate.image.repository }}:{{ .Values.gate.image.tag }}"
         imagePullPolicy: "{{ .Values.gate.image.pullPolicy }}"
         env:
@@ -40,12 +46,12 @@ spec:
           value: "0.0.0.0:8082"
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
           {{- else }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
@@ -65,14 +71,13 @@ spec:
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.port "5432" | quote }}
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
         - name: SCALOCK_AUDIT_DBPASSWORD
+          {{- if .Values.db.passwordFromSecret.enabled }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbAuditPasswordName }}
-              key: {{ .Values.db.dbAuditPasswordKey }}
-          {{- else }}
-        - name: SCALOCK_AUDIT_DBPASSWORD
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+          {{- else if and ( not .Values.db.passwordFromSecret.enabled ) ( .Values.db.external.enabled ) }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
@@ -81,6 +86,11 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
+          {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
           {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
@@ -95,12 +105,12 @@ spec:
         {{- if .Values.activeactive }}
         - name: AQUA_PUBSUB_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPubsubPasswordName }}
-              key: {{ .Values.db.dbPubsubPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPubsubPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPubsubPasswordKey }}
           {{- else }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
@@ -111,7 +121,7 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
-          {{- end }}
+        {{- end }}
         - name: AQUA_PUBSUB_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubName "aqua_pubsub" }}
         - name: AQUA_PUBSUB_DBHOST
@@ -146,6 +156,11 @@ spec:
         readinessProbe:
 {{ toYaml . | indent 10 }}
 {{- end }}
+        {{- if .Values.gate.TLS.enabled }}
+        volumeMounts:
+        - name: certs
+          mountPath: /opt/aquasec/ssl/
+        {{- end }}
         resources:
 {{ toYaml .Values.gate.resources | indent 12 }}
       {{- with .Values.gate.nodeSelector }}
@@ -159,4 +174,11 @@ spec:
       {{- if and (.Values.gate.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
       tolerations:
 {{ toYaml .Values.gate.tolerations | indent 6 }}
+      {{- end }}
+      {{- if .Values.gate.TLS.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.gate.TLS.secretName }}
       {{- end }}

--- a/helm/aqua-app-server/templates/web-deployment.yaml
+++ b/helm/aqua-app-server/templates/web-deployment.yaml
@@ -23,11 +23,17 @@ spec:
         app: {{ .Release.Name }}-console
       name: {{ .Release.Name }}-console
     spec:
+      {{- with .Values.web.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: web
+        {{- with .Values.web.container_securityContext }}
         securityContext:
-          {{- toYaml .Values.web.securityContext | nindent 12 }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
         imagePullPolicy: "{{ .Values.web.image.pullPolicy }}"
         env:
@@ -35,12 +41,12 @@ spec:
           value: {{ .Values.web.logLevel | default "INFO" }}
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
         {{- else }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
@@ -61,14 +67,13 @@ spec:
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.port "5432" | quote }}
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
         - name: SCALOCK_AUDIT_DBPASSWORD
+          {{- if .Values.db.passwordFromSecret.enabled }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbAuditPasswordName }}
-              key: {{ .Values.db.dbAuditPasswordKey }}
-          {{- else }}
-        - name: SCALOCK_AUDIT_DBPASSWORD
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+          {{- else if and ( not .Values.db.passwordFromSecret.enabled ) ( .Values.db.external.enabled ) }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
@@ -77,6 +82,11 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
+          {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
           {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
@@ -91,12 +101,12 @@ spec:
         {{- if .Values.activeactive }}
         - name: AQUA_PUBSUB_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
+          {{- if .Values.db.passwordFromSecret.enabled }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPubsubPasswordName }}
-              key: {{ .Values.db.dbPubsubPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPubsubPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPubsubPasswordName }}
           {{- else }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
@@ -169,6 +179,11 @@ spec:
         - mountPath: /var/run/docker.sock
           name: docker-socket-mount
         {{- end }}
+        {{- if .Values.web.TLS.enabled }}
+        volumeMounts:
+        - name: certs
+          mountPath: /opt/aquasec/ssl/
+        {{- end }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       {{- with .Values.web.nodeSelector }}
@@ -188,4 +203,11 @@ spec:
       - name: docker-socket-mount
         hostPath:
           path: {{ .Values.dockerSock.path }}
+      {{- end }}
+      {{- if .Values.web.TLS.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.web.TLS.secretName }}
       {{- end }}

--- a/helm/aqua-app-server/templates/web-ingress.yaml
+++ b/helm/aqua-app-server/templates/web-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.web.ingress.enabled -}}
 {{- $fullname := .Release.Name -}}
-{{- $servicePort := .Values.web.service.externalPort -}}
+{{- $servicePort := .Values.web.ingress.externalPort -}}
 ---
 {{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1

--- a/helm/aqua-app-server/values.yaml
+++ b/helm/aqua-app-server/values.yaml
@@ -12,6 +12,12 @@ rbac:
   privileged: true
   roleRef: ""
 
+#Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift
+platform: gaintswarm
+
+openshift_route:
+  create: false    #Enable if required openshift route for web and gateway
+
 # enable only one of the modes
 clustermode: false
 activeactive: false
@@ -42,15 +48,25 @@ db:
     pubsubPort: ""
     pubsubUser: ""
     pubsubPassword: ""
-  passwordSecret: ""
-  dbPasswordName: ""
-  dbPasswordKey: ""
-  dbAuditPasswordName: ""
-  dbAuditPasswordKey: ""
-  dbPubsubPasswordName: ""
-  dbPubsubPasswordKey: ""
+
+  passwordFromSecret:
+    enabled: false              #Enable if loading passwords for db and audit-db from secret
+    dbPasswordName: ""            #Specify the Password Secret name used for db password
+    dbPasswordKey: ""             #Specify the db password key name stored in the #dbPasswordName secret
+    dbAuditPasswordName: ""          #Specify the Password Secret name used for audit db password
+    dbAuditPasswordKey: ""            #Specify the audit db password key name stored in the #dbAuditPasswordName secret
+    dbPubsubPasswordName: ""           #Specify the Password Secret name used for pubsub db password
+    dbPubsubPasswordKey: ""           #Specify the pubsub db password key name stored in the #PubsubPasswordName secret
+
   ssl: false
   auditssl: false
+
+  securityContext:
+    runAsUser: 70
+    runAsGroup: 70
+    fsGroup: 11433
+  container_securityContext:
+    privileged: false
   image:
     repository: giantswarm/aqua-database
     tag: "5.3"
@@ -91,7 +107,6 @@ db:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
 
   # extraEnvironmentVars is a list of extra enviroment variables to set in the database deployments.
   extraEnvironmentVars: {}
@@ -141,7 +156,7 @@ gate:
     tcpSocket:
       port: 8443
     initialDelaySeconds: 60
-    periodSeconds: 30
+    periodSeconds: 60
   resources: {}
     # Note: For recommendations please check the official sizing guide.
     # requests:
@@ -153,15 +168,24 @@ gate:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
-  #  runAsUser: 11431
-  #  runAsGroup: 11433
-  #  fsGroup: 11433
+  securityContext:
+    runAsUser: 11431
+    runAsGroup: 11433
+    fsGroup: 11433
+  container_securityContext: {}
+
+  TLS:
+    enabled: false      # change to true for enabling secure communication
+    secretName:         #created certs secret name for gate
+    #Follow Advance configuration for mTLS communication establishment and place your certs in /opt/aquasec/ssl/ path
 
   # extraEnvironmentVars is a list of extra enviroment variables to set in the gateway deployments.
   # https://docs.aquasec.com/docs/gateway-optional-variables
   extraEnvironmentVars: {}
     # ENV_NAME: value
+    #Example for mTLS env variables:
+    #AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/<file_name>"
+    #AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/<file_name>"
 
   # extraSecretEnvironmentVars is a list of extra enviroment variables to set in the gateway deployments.
   # These variables take value from existing Secret objects.
@@ -193,6 +217,7 @@ web:
         protocol: TCP
   ingress:
     enabled: false
+    externalPort:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
     hosts: ""  # REQUIRED
@@ -229,15 +254,25 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
-  #  runAsUser: 11431
-  #  runAsGroup: 11433
-  #  fsGroup: 11433
+  securityContext:
+    runAsUser: 11431
+    runAsGroup: 11433
+    fsGroup: 11433
+  container_securityContext: {}
+
+
+  TLS:
+    enabled: false      # change to true for enabling secure communication
+    secretName:         #created certs secret name for web
+    #Follow Advance configuration for mTLS communication establishment and place your certs in /opt/aquasec/ssl/
 
   # extraEnvironmentVars is a list of extra enviroment variables to set in the web deployments.
   # https://docs.aquasec.com/docs/server-optional-variables
   extraEnvironmentVars: {}
     # ENV_NAME: value
+    #Example for mTLS env variables:
+    #AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/<file_name>"
+    #AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/<file_name>"
 
   # extraSecretEnvironmentVars is a list of extra enviroment variables to set in the web deployments.
   # These variables take value from existing Secret objects.


### PR DESCRIPTION
1. Adding security context for server components
2. Adding init-containers for Db pods to fix permission issue raised after the security context
3. Fixing DB passwords pulling from secrets bug and added flag (passwordFromSecret.enabled) for clear understanding.
4. Added Mutual TLS between server and gateway code in comments can be enabled on a conditional basis.