### PR TITLE
Fix reference to `serviceAccount`

### DIFF
--- a/helm/aqua-app-scanner/templates/scanner-deployment.yaml
+++ b/helm/aqua-app-scanner/templates/scanner-deployment.yaml
@@ -23,7 +23,11 @@ spec:
         app: {{ .Release.Name }}-scanner
       name: {{ .Release.Name }}-scanner
     spec:
+      {{- if not .Values.serviceAccount}}
+      serviceAccount: {{ .Release.Name }}-sa
+      {{- else }}
       serviceAccount: {{ .Values.serviceAccount }}
+      {{- end }}
       containers:
       - name: scanner
         securityContext:


### PR DESCRIPTION
See https://github.com/giantswarm/aqua-app/blob/master/helm/aqua-app-scanner/templates/serviceaccount.yaml
When serviceAccount is created it should be used.